### PR TITLE
Fix NaN for casting from floats or strings

### DIFF
--- a/src/enums.rs
+++ b/src/enums.rs
@@ -85,7 +85,9 @@ impl DataElement {
 
     /// Get a [`DataElement`] from a `&str` value.
     // TODO: Add support for parsing f32 vs f64 and etc.
-    pub fn from_parse(val: &str) -> DataElement {
+    pub fn from_parse<S: Into<String>>(val: S) -> DataElement {
+
+        let val: String = val.into();
 
         // Attempt i64
         match val.parse::<i64>().ok() {
@@ -101,6 +103,26 @@ impl DataElement {
                     None => panic!("Unable to parse value!")
                 }
             }
+        }
+    }
+
+    /// Get the current [`DType`]
+    pub fn dtype(&self) -> DType {
+        match self {
+            DataElement::I64(_) => DType::I64,
+            DataElement::F64(_) => DType::F64,
+            DataElement::I32(_) => DType::I32,
+            DataElement::F32(_) => DType::F32,
+            DataElement::STRING(_) => DType::STRING
+        }
+    }
+
+    /// Determine if the `DataElement` holds an `NaN` value
+    pub fn is_nan(&self) -> bool {
+        match self {
+            DataElement::F64(v) => v.is_nan(),
+            DataElement::F32(v) => v.is_nan(),
+            _ => false // Integers and Strings not allowed to be NaN
         }
     }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -26,7 +26,11 @@ macro_rules! impl_FROM_DataElement_for_primitive {
                     DataElement::F64(v) => v as $primitive,
                     DataElement::I32(v) => v as $primitive,
                     DataElement::F32(v) => v as $primitive,
-                    _ => panic!("Unable to implement From<DataElement>, is primitive a String?")
+                    DataElement::STRING(v) => {
+                        let nan: f64 = Float::nan();
+                        v.parse::<$primitive>()
+                            .unwrap_or(nan as $primitive)
+                    }
                 }    
             }
         }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -176,11 +176,11 @@ pub trait SeriesTrait: Debug + Sized + Any {
     fn dtype(&self) -> Option<DType>;
 
     /// Cast all [`DataElement`]s within a series to a given [`DType`]
-    /// Will _NOT_ fail; elements which cannot be coerced into some type will
-    /// be given an `NaN` value as a result.
+    /// Will fail if series contains a string and asking for an integer
     /// 
-    /// ie. "Hello" -> .astype([`DType::I64`]) -> `NaN`
-    fn astype(&mut self, dtype: DType) -> ();
+    /// ie. "Hello" -> .astype([`DType::I64`]) -> **Error!**
+    /// ie. "Hello" -> .astype([`DType::F64`]) -> `NaN`
+    fn astype(&mut self, dtype: DType) -> Result<(), &'static str>;
 
     /// As boxed pointer, recoverable by `Box::from_raw(ptr)` or `SeriesTrait::from_raw(*mut Self)`
     fn into_raw(self) -> *mut Self { 


### PR DESCRIPTION
Closes #30 

Adds `dtype()` and `is_nan()` to `DataElement` as part of the process.