### PR TITLE
Update IndexMut to only grab existing series, more tests

### DIFF
--- a/src/dataframe/mod.rs
+++ b/src/dataframe/mod.rs
@@ -12,7 +12,7 @@
 //! ```
 //!
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ops::{Index, IndexMut};
 use std::path::Path;
 use std::error::Error;
@@ -133,6 +133,11 @@ impl ColumnManager for DataFrame {
     fn n_columns(&self) -> usize {
         self.series_objects.len() as usize
     }
+
+    fn columns(&self) -> HashSet<&String> {
+        let columns: HashSet<&String> = self.series_objects.keys().collect();
+        columns
+}
 }
 
 // Support `let series = &DataFrame["some-column-name"]`
@@ -152,15 +157,11 @@ impl<S: Into<String>> Index<S> for DataFrame {
 // Support `DataFrame["some-column-name"] = some_series;`
 impl<S: Into<String>> IndexMut<S> for DataFrame {
     fn index_mut(&mut self, name: S) -> &mut Series {
-        // TODO: Find a way to error if mismatch in series sizes.
         let name: String = name.into();
 
-        // Create a series and set the name to the name given here
-        let mut series = Series::arange(0, 10);
-        series.set_name(&name);
-        self.add_column(series);
-
-        // Fetch back the column as a mutable reference.
-        self.get_column_mut(&name).unwrap()
+        match self.get_column_mut(&name) {
+            Some(series) => series,
+            None => panic!("No column named: '{}'", name)
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,9 +22,9 @@
 //! // Or not... 
 //! assert_eq!(series_i32.name(), None);
 //! 
-//! // Add columns (of different types) to a dataframe, by method or index assignment
+//! // Add columns (of different types) to a dataframe
 //! df.add_column(series_i32);
-//! df["my-float-series"] = series_f64;
+//! df.add_column(series_f64);
 //! 
 //! // Get columns by either method or indexing it
 //! let series_ref: Option<&Series> = df.get_column("my-float-series");

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -6,6 +6,7 @@ use std::any::{Any};
 use std::iter::{Sum};
 use std::path::Path;
 use std::error::Error;
+use std::collections::HashSet;
 
 use num::*;
 use prelude::*;
@@ -72,6 +73,9 @@ pub trait ColumnManager {
 
     /// Get the number of columns
     fn n_columns(&self) -> usize;
+
+    /// Return the current dataframe's columns
+    fn columns(&self) -> HashSet<&String>;
 }
 
 /// Represents behavior for [`DataFrame`] io behavior

--- a/tests/dataframe_tests.rs
+++ b/tests/dataframe_tests.rs
@@ -5,13 +5,48 @@ use blackjack::prelude::*;
 
 
 #[test]
+fn test_index_mut() {
+    let mut df = DataFrame::new();
+    let mut s1 = Series::arange(0, 5);
+    s1.set_name("s1");
+    df.add_column(s1);
+
+    let s1 = Series::arange(5, 10);
+    let sc = s1.clone();
+    df["s1"] = s1;
+
+    assert_eq!(&df["s1"], &sc);
+}
+
+#[test]
+fn test_column_names() {
+    use std::collections::HashSet;
+    use std::iter::FromIterator;
+
+    let mut s1 = Series::arange(0, 2);
+    let mut s2 = Series::arange(1, 3);
+
+    let mut df = DataFrame::new();
+
+    s1.set_name("s1");
+    s2.set_name("s2");
+    df.add_column(s1);
+    df.add_column(s2);
+
+    assert_eq!(
+        df.columns(), 
+        HashSet::from_iter(vec![&"s1".to_string(), &"s2".to_string()])
+    );
+}
+
+#[test]
 fn test_pretty_display() {
     let mut df = DataFrame::new();
     let s1 = Series::arange(0, 5);
     let s2 = Series::arange(5, 10);
 
-    df["s1"] = s1;
-    df["s2"] = s2;
+    df.add_column(s1);
+    df.add_column(s2);
 
     println!("{}", df);
 }
@@ -46,8 +81,8 @@ fn test_add_columns() {
     let series2_clone = series2.clone();
 
     // Add both columns
-    df.add_column(series1);   // Add by method
-    df["series-2"] = series2; // Add by IndexMut
+    df.add_column(series1);
+    df.add_column(series2);
     
     {
         // Test the columns match

--- a/tests/series_tests.rs
+++ b/tests/series_tests.rs
@@ -35,9 +35,18 @@ fn test_actions_on_various_element_series() {
         DataElement::STRING("hi".to_string())
     ]);
 
-    // Test that trying to convert series to Integer, containing a String, 
+    // Test that trying to convert series to I32, containing a String, 
     // results in an Error
     match series.astype(DType::I32) {
+        Ok(()) => {
+            panic!("Should not have been able to convert a String to NaN integer")
+        },
+        Err(_) => println!("Unable to convert String value to Integer! TEST PASSED!")
+    };
+
+    // Test that trying to convert series to I64, containing a String, 
+    // results in an Error
+    match series.astype(DType::I64) {
         Ok(()) => {
             panic!("Should not have been able to convert a String to NaN integer")
         },


### PR DESCRIPTION
Found unable to close the issue #33 until an `IndexAssign` trait becomes available in Rust.